### PR TITLE
sqlite3 > 1.5.4 requires ruby 2.7

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 
 group :development, :test do
   gem "pry-byebug"
-  gem "sqlite3", "~> 1.6.3"
+  gem "sqlite3", "~> 1.5.4"
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.3)
+    sqlite3 (1.5.4)
       mini_portile2 (~> 2.8.0)
     thor (1.2.1)
     tilt (2.0.9)
@@ -281,7 +281,7 @@ DEPENDENCIES
   rollbar
   rubocop-rails_config
   sass-rails (~> 6.0)
-  sqlite3 (~> 1.6.3)
+  sqlite3 (~> 1.5.4)
   uglifier (>= 1.3.0)
 
 RUBY VERSION


### PR DESCRIPTION
version 1.5.4 is the last one for Ruby 2.6

fixes #284 